### PR TITLE
Add space before specifier 

### DIFF
--- a/create_feedstock_meta_yaml/create_feedstock_meta_yaml.py
+++ b/create_feedstock_meta_yaml/create_feedstock_meta_yaml.py
@@ -126,13 +126,25 @@ def clean_reqs(reqs):
         if len(req) > 1:
             package = Requirement(req)
             pypi_name = package.name
-            # import pdb;pdb.set_trace();
             if pypi_name in pypi_to_conda:
-                pypi_name = pypi_to_conda.get(pypi_name) + " " + str(package.specifier)
+                pypi_name = create_pypi_name(
+                    pypi_to_conda.get(pypi_name),
+                    package.specifier,
+                )
             else:
-                pypi_name = package.name + " " + str(package.specifier)
+                pypi_name = create_pypi_name(package.name, package.specifier)
             new_reqs.append(pypi_name)
     return new_reqs
+
+
+def create_pypi_name(package_name, specifier):
+    pypi_name = package_name
+    for idx, x in enumerate(specifier):
+        if idx == 0:
+            pypi_name += " " + str(x)
+        else:
+            pypi_name += ", " + str(x)
+    return pypi_name
 
 
 def clean_cfg_section(section):

--- a/create_feedstock_meta_yaml/create_feedstock_meta_yaml.py
+++ b/create_feedstock_meta_yaml/create_feedstock_meta_yaml.py
@@ -128,10 +128,9 @@ def clean_reqs(reqs):
             pypi_name = package.name
             # import pdb;pdb.set_trace();
             if pypi_name in pypi_to_conda:
-                pypi_name = pypi_to_conda.get(pypi_name) + str(package.specifier)
+                pypi_name = pypi_to_conda.get(pypi_name) + " " + str(package.specifier)
             else:
-                pypi_name = package.name + str(package.specifier)
-            pypi_name = pypi_name.replace(">=", " >=")
+                pypi_name = package.name + " " + str(package.specifier)
             new_reqs.append(pypi_name)
     return new_reqs
 

--- a/create_feedstock_meta_yaml/create_feedstock_meta_yaml.py
+++ b/create_feedstock_meta_yaml/create_feedstock_meta_yaml.py
@@ -139,7 +139,9 @@ def clean_reqs(reqs):
 
 def create_pypi_name(package_name, specifier):
     pypi_name = package_name
-    for idx, x in enumerate(specifier):
+    specs = [str(x) for x in specifier]
+    specs.sort()
+    for idx, x in enumerate(specs):
         if idx == 0:
             pypi_name += " " + str(x)
         else:

--- a/create_feedstock_meta_yaml/expected_meta.yaml
+++ b/create_feedstock_meta_yaml/expected_meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - distributed >=2021.10.0
     - holidays >=0.13
     - numpy >=1.21.0
-    - pandas >=1.3.0
+    - pandas >=1.4.0, !=1.4.2
     - psutil >=5.6.6
     - python >=3.7.*
     - scipy >=1.3.3

--- a/create_feedstock_meta_yaml/expected_meta.yaml
+++ b/create_feedstock_meta_yaml/expected_meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - distributed >=2021.10.0
     - holidays >=0.13
     - numpy >=1.21.0
-    - pandas !=1.4.2, >=1.4.0"
+    - pandas !=1.4.2, >=1.4.0
     - psutil >=5.6.6
     - python >=3.7.*
     - scipy >=1.3.3

--- a/create_feedstock_meta_yaml/expected_meta.yaml
+++ b/create_feedstock_meta_yaml/expected_meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - distributed >=2021.10.0
     - holidays >=0.13
     - numpy >=1.21.0
-    - pandas >=1.4.0, !=1.4.2
+    - pandas !=1.4.2, >=1.4.0"
     - psutil >=5.6.6
     - python >=3.7.*
     - scipy >=1.3.3

--- a/create_feedstock_meta_yaml/test_create_feedstock_meta_yaml.py
+++ b/create_feedstock_meta_yaml/test_create_feedstock_meta_yaml.py
@@ -60,7 +60,7 @@ def verify_cmeta(cmeta, pypi_version):
         "distributed >=2021.10.0",
         "holidays >=0.13",
         "numpy >=1.21.0",
-        "pandas >=1.3.0",
+        "pandas !=1.4.2, >=1.4.0",
         "psutil >=5.6.6",
         "python >=3.7.*",
         "scipy >=1.3.3",

--- a/create_feedstock_meta_yaml/test_pyproject.toml
+++ b/create_feedstock_meta_yaml/test_pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "distributed >= 2021.10.0",
     "holidays >= 0.13",
     "numpy >= 1.21.0",
-    "pandas >= 1.3.0",
+    "pandas >= 1.4.0, != 1.4.2",
     "psutil >= 5.6.6",
     "scipy >= 1.3.3",
     "tqdm >= 4.32.0",

--- a/create_feedstock_meta_yaml/test_setup.cfg
+++ b/create_feedstock_meta_yaml/test_setup.cfg
@@ -1,4 +1,5 @@
 [options]
+python_requires = >=3.8, <4
 install_requires =
     click >= 7.0.0
     cloudpickle >= 1.5.0
@@ -11,7 +12,6 @@ install_requires =
     scipy >= 1.3.3
     tqdm >= 4.32.0
     woodwork >= 0.16.2
-python_requires = >=3.8, <4
 
 [options.extras_require]
 test =

--- a/create_feedstock_meta_yaml/test_setup.cfg
+++ b/create_feedstock_meta_yaml/test_setup.cfg
@@ -6,7 +6,7 @@ install_requires =
     distributed >= 2021.10.0
     holidays >= 0.13
     numpy >= 1.21.0
-    pandas >= 1.3.0
+    pandas >= 1.4.0, != 1.4.2
     psutil >= 5.6.6
     scipy >= 1.3.3
     tqdm >= 4.32.0


### PR DESCRIPTION
- Fixes the following error:
```python
requirements: run: pandas!=1.4.2, >=1.4.0 must contain a space between the name and the pin, i.e. pandas! =1.4.2,>=1.4.0
```